### PR TITLE
fixes and simplifies tar extraction

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,9 +80,8 @@ class phantomjs (
 
   exec { 'get phantomjs':
     command => "/usr/bin/curl --silent --show-error --location ${pkg_src_url} --output ${source_dir}/phantomjs.tar.bz2 \
-      && mkdir ${source_dir}/phantomjs && tar xjf ${source_dir}/phantomjs.tar.bz2 -C ${source_dir} \
-      && mv ${source_dir}/phantomjs-${package_version}-linux-x86_64/* ${source_dir}/phantomjs/ \
-      && rm -rf ${source_dir}/phantomjs-${package_version}-linux-x86_64",
+      && mkdir ${source_dir}/phantomjs \
+      && tar --extract --file=${source_dir}/phantomjs.tar.bz2 --strip-components=1 --directory=${source_dir}/phantomjs",
     creates => "${source_dir}/phantomjs/",
     require => $packages
   }


### PR DESCRIPTION
It seems that ariya (creator of phantomjs) changed his naming scheme for the extracted tarball - I was getting a bunch of errors on Ubuntu 14.04 when I tried to use your module to install phantomjs. This change makes that extraction a one-liner and does not require an intermediate directory.
