### PR TITLE
Added timeout fix for slow connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Using
 		package_update => true,
 		install_dir => '/usr/local/bin',
 		source_dir => '/opt',
+		timeout => 300
 	}
 
 The module pulls in *curl*, *bzip2* and *libfontconfig1* if you haven't defined those packages yourself.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@ class phantomjs (
   $source_dir = '/opt',
   $install_dir = '/usr/local/bin',
   $package_update = false,
-
+  $timeout = 300
 ) {
 
   # Base requirements
@@ -93,7 +93,8 @@ class phantomjs (
       && mkdir ${source_dir}/phantomjs \
       && tar --extract --file=${source_dir}/phantomjs.tar.bz2 --strip-components=1 --directory=${source_dir}/phantomjs",
     creates => "${source_dir}/phantomjs/",
-    require => $packages
+    require => $packages,
+    timeout => $timeout
   }
 
   file { "${install_dir}/phantomjs":


### PR DESCRIPTION
The phantomjs install is failing for the timeout if the download takes too long. This change will allow the timeout to be set up the user if they are having problems