### PR TITLE
Fail call to curl if resource does not exist

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,7 +57,7 @@ class phantomjs (
   }
 
   exec { 'get phantomjs':
-    command => "/usr/bin/curl --silent --show-error --location ${pkg_src_url} --output ${source_dir}/phantomjs.tar.bz2 \
+    command => "/usr/bin/curl --silent --show-error --fail --location ${pkg_src_url} --output ${source_dir}/phantomjs.tar.bz2 \
       && mkdir ${source_dir}/phantomjs \
       && tar --extract --file=${source_dir}/phantomjs.tar.bz2 --strip-components=1 --directory=${source_dir}/phantomjs",
     creates => "${source_dir}/phantomjs/",


### PR DESCRIPTION
I've had a few runs of this module where Bitbucket (for whatever reason) 404's when `curl` attempts to retrieve `phantomjs.tar.bz2`. This has an unintentional side-effect in that `--output` is still written. The contents of that output is the HTTP response from Bitbucket saying, "Whoops, not found." (paraphrase).

This causes subsequent runs of the module to think that "all is well" and not actually download the tarball.

This patch adds the `--fail` flag to the `curl` call so that if `curl` cannot retrieve the tarball, it will abort without writing an "empty" tarball to the file-system and tricking the `creates` entry for `get phantomjs` to pass on a subsequent run.
